### PR TITLE
downgrade to 3.36 until we figure out the portal thing

### DIFF
--- a/im.bernard.Nostalgia.json
+++ b/im.bernard.Nostalgia.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "im.bernard.Nostalgia",
     "runtime" : "org.gnome.Platform",
-    "runtime-version" : "3.38",
+    "runtime-version" : "3.36",
     "sdk" : "org.gnome.Sdk",
     "command" : "nostalgia",
     "finish-args" : [


### PR DESCRIPTION
Looks like we need to switch to a more sandbox friendly way to set the wallpaper, reverting to 3.36 might fix it in the meatime.