### PR TITLE
Add dri permission

### DIFF
--- a/im.bernard.Nostalgia.json
+++ b/im.bernard.Nostalgia.json
@@ -5,6 +5,7 @@
     "sdk" : "org.gnome.Sdk",
     "command" : "nostalgia",
     "finish-args" : [
+        "--device=dri",
         "--share=ipc",
         "--socket=fallback-x11",
         "--socket=wayland"


### PR DESCRIPTION
GTK 4 is rendered on GPU and thus needs this new permission.